### PR TITLE
完善uncle分析器，依赖更新至1.0.26

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -6,7 +6,7 @@ props.load(file("../gradle.properties").newDataInputStream())
 dependencyManagement {
     dependencies {
         dependency "com.unclezs:jfx-launcher:${props.getProperty("app.launcher.version")}"
-        dependency "com.unclezs:novel-analyzer:1.0.24"
+        dependency "com.unclezs:novel-analyzer:1.0.26"
 
         dependencySet("cn.hutool:5.8.0") {
             entry "hutool-all"


### PR DESCRIPTION
com.unclezs:novel-analyzer:1.0.26
1.修复二次下载时文件序号没有连续的问题
2.添加书籍信息在txt开头
3.添加js工具方法utils.bytes

<!--- 感谢你为Uncle小说做出的贡献! :-) -->

### 本次PR的主要内容
